### PR TITLE
Implement post-snapshot delta handling in compaction

### DIFF
--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -1686,7 +1686,8 @@ impl Store {
                 let delta_tags_count = delta_tags.len() / tags::TAG_ENTRY_SIZE;
                 let mut new_tags = OpenOptions::new().append(true).open(&tmp_tags_path)?;
                 for j in 0..delta_tags_count {
-                    let b: &[u8; tags::TAG_ENTRY_SIZE] = delta_tags[j * tags::TAG_ENTRY_SIZE..(j + 1) * tags::TAG_ENTRY_SIZE]
+                    let b: &[u8; tags::TAG_ENTRY_SIZE] = delta_tags
+                        [j * tags::TAG_ENTRY_SIZE..(j + 1) * tags::TAG_ENTRY_SIZE]
                         .try_into()
                         .unwrap();
                     let te = tags::TagEntry::from_bytes(b);
@@ -3415,10 +3416,7 @@ mod tests {
             .unwrap();
 
         for id in &appended_ids {
-            assert!(
-                found_ids.contains(id),
-                "event appended during compaction must survive"
-            );
+            assert!(found_ids.contains(id), "event appended during compaction must survive");
         }
     }
 }


### PR DESCRIPTION
Capture snapshot offsets at phase 1 to detect events appended during compaction.
In phase 3, under the writer lock, copy delta data and index entries from all
four files (data, index, tags, dtags) into the compacted files, adjusting
data_offset pointers to account for the new layout. Add test to verify events
appended during compaction are preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes - Compaction Delta Handling

- **Compaction's Mid-Life Crisis Resolved**: The compaction process used to have an existential crisis during phase 2—events appended to the database would vanish into the void like forgotten socks in a dryer. No longer! We now capture snapshot offsets at the start of compaction to track any stragglers that arrive fashionably late. When the writer lock finally drops its velvet rope in phase 3, we gracefully fold these delta events into the newly compacted files.

- **Data Offset Tango**: During compaction, we're essentially performing a complex choreography where data slides around in the compacted files. To ensure index, tags, and dtags entries still point to the right dancers, we calculate and apply a `data_offset` shift to all delta entries. Think of it as giving every post-snapshot record a new home address before they get lost in the file system shuffle.

- **The Golden Ticket Test**: A new unit test (`test_compact_preserves_events_appended_during_compaction`) now ensures that compaction doesn't lose its nerve—or your data. It runs compaction and appends concurrently, verifying that every successfully written event remains queryable after the dust settles. Consider it the compaction process' performance review.

| File | Lines Added | Lines Removed | Notable Contribution |
|------|-------------|---------------|----------------------|
| `src/db/store.rs` | +155 | -1 | Vanquished a data loss dragon; awarded the Medal of Concurrent Integrity |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->