### PR TITLE
Add max_neg_records config and enforce negentropy session limits

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,9 @@ pub struct Config {
     pub relay_url: String,
     /// Interval in seconds between background compaction runs. 0 = disabled. Default: 21600 (6h).
     pub compact_interval: u64,
+    /// Maximum number of records allowed in a single negentropy session. Default: 500_000.
+    /// If a NEG-OPEN filter matches more events than this, the server responds with NEG-ERR.
+    pub max_neg_records: usize,
 }
 
 impl Default for Config {
@@ -52,6 +55,7 @@ impl Default for Config {
                 .unwrap_or_else(|_| std::path::PathBuf::from("./data")),
             relay_url,
             compact_interval: env_parse("FASTR_COMPACT_INTERVAL", 21600),
+            max_neg_records: env_parse("FASTR_MAX_NEG_RECORDS", 500_000),
         }
     }
 }

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -1323,7 +1323,13 @@ impl Store {
     /// # Errors
     ///
     /// Returns an `Err` if internal locking fails (e.g., tombstone lock is poisoned).
-    pub fn iter_negentropy<F>(&self, filter: &Filter, auth_pk: Option<&[u8; 32]>, mut f: F) -> Result<(), Error>
+    pub fn iter_negentropy<F>(
+        &self,
+        filter: &Filter,
+        auth_pk: Option<&[u8; 32]>,
+        max_records: usize,
+        mut f: F,
+    ) -> Result<(), Error>
     where
         F: FnMut(i64, [u8; 32]),
     {
@@ -1420,6 +1426,9 @@ impl Store {
                 }
             }
 
+            if items.len() >= max_records {
+                return Err(Error::Rejected("too many records for negentropy session"));
+            }
             items.push((entry.created_at, entry.id));
         }
 

--- a/src/nostr/mod.rs
+++ b/src/nostr/mod.rs
@@ -177,6 +177,8 @@ pub enum ServerMsg<'a> {
     NegMsg {
         sub_id: &'a str,
         msg: &'a [u8],
+        /// Optional maximum number of records the relay supports per negentropy session.
+        max_records: Option<usize>,
     },
     /// NIP-77: server error for a negentropy session.
     NegErr {
@@ -727,13 +729,17 @@ impl ServerMsg<'_> {
                     serde_json::to_string(message).expect("message serialization"),
                 )
             }
-            ServerMsg::NegMsg { sub_id, msg } => {
+            ServerMsg::NegMsg {
+                sub_id,
+                msg,
+                max_records,
+            } => {
                 let hex = hex_encode_bytes(msg);
-                format!(
-                    "[\"NEG-MSG\",{},\"{}\"]",
-                    serde_json::to_string(sub_id).expect("sub_id serialization"),
-                    hex,
-                )
+                let sub = serde_json::to_string(sub_id).expect("sub_id serialization");
+                match max_records {
+                    Some(max) => format!("[\"NEG-MSG\",{},\"{}\",{}]", sub, hex, max),
+                    None => format!("[\"NEG-MSG\",{},\"{}\"]", sub, hex),
+                }
             }
             ServerMsg::NegErr { sub_id, reason } => {
                 format!(

--- a/src/ws/handler.rs
+++ b/src/ws/handler.rs
@@ -579,7 +579,7 @@ async fn handle_neg_open(
     let mut storage = NegentropyStorageVector::new();
     let mut insert_error: Option<String> = None;
 
-    if let Err(e) = store.iter_negentropy(&filter, auth_pk, |ts, id| {
+    if let Err(e) = store.iter_negentropy(&filter, auth_pk, config.max_neg_records, |ts, id| {
         if insert_error.is_none() {
             if let Err(e) = storage.insert(ts as u64, NegId::from_byte_array(id)) {
                 insert_error = Some(e.to_string());
@@ -642,6 +642,7 @@ async fn handle_neg_open(
             let resp = ServerMsg::NegMsg {
                 sub_id: &sub_id,
                 msg: &reply,
+                max_records: Some(config.max_neg_records),
             }
             .to_json();
             let _ = out_tx.send(Out::Text(resp)).await;
@@ -696,6 +697,7 @@ async fn handle_neg_msg(sub_id: String, msg: Vec<u8>, out_tx: &mpsc::Sender<Out>
             let resp = ServerMsg::NegMsg {
                 sub_id: &sub_id,
                 msg: &reply,
+                max_records: None,
             }
             .to_json();
             let _ = out_tx.send(Out::Text(resp)).await;
@@ -1847,6 +1849,99 @@ mod tests {
             v[1].as_str().unwrap_or("").contains("too many"),
             "NOTICE should mention subscription limit: {resp}",
         );
+    }
+
+    /// Verifies that NEG-OPEN rejects sessions that exceed `max_neg_records`.
+    ///
+    /// Spawns a server with `max_neg_records = 3`, stores 5 events, and opens a NEG-OPEN
+    /// with a broad filter. The server should respond with NEG-ERR.
+    #[tokio::test]
+    async fn test_neg_open_rejects_when_exceeding_max_records() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(Store::open(&dir.keep()).unwrap());
+        let config = Arc::new(Config {
+            relay_url: format!("ws://127.0.0.1:{port}"),
+            max_neg_records: 3,
+            ..Config::default()
+        });
+        let fanout = Fanout::new();
+        let srv_store = Arc::clone(&store);
+        let srv_config = Arc::clone(&config);
+        let srv_fanout = Arc::clone(&fanout);
+        tokio::spawn(async move {
+            loop {
+                if let Ok((stream, peer)) = listener.accept().await {
+                    let s = Arc::clone(&srv_store);
+                    let c = Arc::clone(&srv_config);
+                    let f = Arc::clone(&srv_fanout);
+                    tokio::spawn(async move {
+                        let _ = handle_connection(stream, peer, s, c, f).await;
+                    });
+                }
+            }
+        });
+
+        // Store 5 events — exceeds the limit of 3.
+        for i in 1..=5 {
+            store.append(&make_event(i, 1, 1000 + i as i64, vec![])).unwrap();
+        }
+
+        let (_, hex_msg) = neg_initiate(&[]);
+        let mut ws = connect(port).await;
+
+        let raw = format!(r#"["NEG-OPEN","s1",{{}},"{hex_msg}"]"#);
+        ws.send(TMsg::Text(raw.into())).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v[0], "NEG-ERR", "expected NEG-ERR when records exceed limit: {resp}");
+        assert!(
+            v[2].as_str().unwrap_or("").contains("too many records"),
+            "NEG-ERR reason should mention too many records: {resp}",
+        );
+    }
+
+    /// Verifies that NEG-MSG includes the max_records as a 4th element.
+    #[tokio::test]
+    async fn test_neg_msg_includes_max_records() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(Store::open(&dir.keep()).unwrap());
+        let config = Arc::new(Config {
+            relay_url: format!("ws://127.0.0.1:{port}"),
+            max_neg_records: 100,
+            ..Config::default()
+        });
+        let fanout = Fanout::new();
+        let srv_store = Arc::clone(&store);
+        let srv_config = Arc::clone(&config);
+        let srv_fanout = Arc::clone(&fanout);
+        tokio::spawn(async move {
+            loop {
+                if let Ok((stream, peer)) = listener.accept().await {
+                    let s = Arc::clone(&srv_store);
+                    let c = Arc::clone(&srv_config);
+                    let f = Arc::clone(&srv_fanout);
+                    tokio::spawn(async move {
+                        let _ = handle_connection(stream, peer, s, c, f).await;
+                    });
+                }
+            }
+        });
+
+        store.append(&make_event(1, 1, 1000, vec![])).unwrap();
+
+        let (_, hex_msg) = neg_initiate(&[]);
+        let mut ws = connect(port).await;
+
+        let raw = format!(r#"["NEG-OPEN","s1",{{}},"{hex_msg}"]"#);
+        ws.send(TMsg::Text(raw.into())).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v[0], "NEG-MSG", "expected NEG-MSG: {resp}");
+        assert_eq!(v[3], 100, "4th element should be max_neg_records: {resp}");
     }
 
     /// Verifies that omitting the `limit` field in a REQ filter respects `max_limit` config.


### PR DESCRIPTION
Introduces a configurable upper bound on the number of records that can be matched in a single negentropy session. NEG-OPEN now rejects filters that would return more than `max_neg_records` (default: 500,000) with a NEG-ERR response. The limit is communicated to clients in NEG-MSG as a 4th element when present in NEG-OPEN responses, allowing for future negotiation. The store's iter_negentropy method now validates record counts before returning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Negentropy Session Limits — A Tale of Boundaries and Good Governance

- **The Plot Thickens in Config**: A new configuration field `max_neg_records` has arrived on the scene, set to a sensible default of 500,000 records per negentropy session. It reads from the environment variable `FASTR_MAX_NEG_RECORDS` with the grace of a butler, or defaults to its modest preset. Like a bouncer at an exclusive club, it knows exactly when to say "no mas."

- **Store's Newfound Discipline**: The `iter_negentropy` method has been fitted with a `max_records` parameter and now plays hardball—the moment it approaches the limit, it throws up its hands and returns a graceful `Err(Rejected("too many records for negentropy session"))` rather than drowning in an endless flood of data. It's learned the virtue of knowing when to stop.

- **NEG-MSG Gets an Upsell**: Server responses now optionally include the negotiated `max_records` limit in their 4-element JSON frame format. On initial NEG-OPEN, clients learn the house rules via `["NEG-MSG", sub_id, hex, max_records]`; on subsequent reconciliations, it gracefully omits this detail with a simple 3-element frame. A dance of information disclosure.

- **Handler Enforcement Theater**: The websocket handler now conscientiously passes `config.max_neg_records` down to the store's iteration logic, and generates appropriately flavored NEG-MSG responses—armed with the limit on first contact, then flying solo on follow-ups.

- **Test Coverage, The Unsung Hero**: Two new integration tests stand guard—one verifies that oversized filter requests get firmly rejected, the other confirms that the negotiated limit makes it into the response frame where clients can read it. Peace through verification.

## Battle Casualties

| File | Added | Removed | Net Change |
|------|-------|---------|-----------|
| `src/config.rs` | 4 | 0 | +4 |
| `src/db/store.rs` | 10 | 1 | +9 |
| `src/nostr/mod.rs` | 12 | 6 | +6 |
| `src/ws/handler.rs` | 96 | 1 | +95 |
| **TOTAL** | **122** | **8** | **+114** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->