### PR TITLE
Enforce max_message_bytes at WebSocket frame level

### DIFF
--- a/src/ws/handler.rs
+++ b/src/ws/handler.rs
@@ -959,12 +959,19 @@ mod tests {
         // closes the connection rather than buffering the full message.
         // Drain any pending messages (e.g. AUTH challenge) until we see close/error.
         use futures_util::StreamExt;
+        use std::time::Duration;
         loop {
-            match ws.next().await {
-                None => break,
-                Some(Err(_)) => break,
-                Some(Ok(TMsg::Close(_))) => break,
-                Some(Ok(_)) => continue, // skip AUTH, Ping, etc.
+            match tokio::time::timeout(Duration::from_secs(2), ws.next()).await {
+                Err(_elapsed) => panic!("drain loop timed out waiting for close/error"),
+                Ok(None) => break,
+                Ok(Some(Err(_))) => break,
+                Ok(Some(Ok(TMsg::Close(_)))) => break,
+                Ok(Some(Ok(TMsg::Text(ref t)))) => {
+                    assert!(!t.contains("NOTICE"), "unexpected NOTICE from server: {t}");
+                    // Non-NOTICE text (e.g. AUTH challenge) is fine — keep draining.
+                }
+                Ok(Some(Ok(TMsg::Ping(_) | TMsg::Pong(_)))) => {}
+                Ok(Some(Ok(frame))) => panic!("unexpected frame: {frame:?}"),
             }
         }
     }


### PR DESCRIPTION
The handler now configures tokio-tungstenite with max_frame_size and max_message_size limits derived from config.max_message_bytes. This ensures the server closes connections that attempt to send oversized frames, rather than buffering them. The test is updated to verify that oversized messages trigger connection closure instead of a NOTICE response.

Closes #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- WebSocket bouncer upgrades from polite doorman to stern nightclub manager: tokio-tungstenite now receives a custom WebSocketConfig so max_frame_size and max_message_size are set from config.max_message_bytes. Oversized frames are kicked out at the frame-assembly stage instead of being silently buffered until the app notices—memory amplification via chatty malefactors is dramatically less likely. (Closes #25)

- Redundant second line of defense kept (and applauded): the application-level max_message_bytes check remains as a safety net after tungstenite-level enforcement. Because two layers of protection are better than one armor plate.

- Test rewritten to match reality: the old "NOTICE and carry on" expectation has been retired with honors. The oversized-message integration test now asserts that an oversized REQ results in connection termination (server drops the connection) rather than returning a NOTICE after buffering massive junk. The test also tolerates incidental protocol chatter (AUTH, etc.) while ensuring no NOTICE is emitted.

- No public API casualties: no exported function or type signatures were altered—only internal behavior tightened.

| File | Added | Removed |
|------|-------:|--------:|
| `src/ws/handler.rs` | 36 | 9 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->