### PR TITLE
Enforce advertised NIP-11 relay limits

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 
 /// Relay configuration, loaded from environment variables at startup.
@@ -29,6 +30,17 @@ pub struct Config {
     /// Maximum number of records allowed in a single negentropy session. Default: 500_000.
     /// If a NEG-OPEN filter matches more events than this, the server responds with NEG-ERR.
     pub max_neg_records: usize,
+    /// Maximum number of tags allowed on an incoming event. Default: 2000.
+    pub max_event_tags: usize,
+    /// Per-kind maximum content length (in bytes). Every kind falls back to the global default
+    /// (FASTR_MAX_CONTENT_LENGTH, default 50 KiB). Individual kinds can be overridden via
+    /// `FASTR_MAX_CONTENT_LENGTH_PER_KIND` as comma-separated `kind:bytes` pairs,
+    /// e.g. `30023:102400`.
+    /// NIP-11 `max_content_length` is reported as the limit for kind 1.
+    pub max_content_length_per_kind: HashMap<u16, usize>,
+    /// Global default content length limit. Kinds not in max_content_length_per_kind use this.
+    /// Default: 50 KiB (51200). Override with `FASTR_MAX_CONTENT_LENGTH`.
+    pub max_content_length: usize,
 }
 
 impl Default for Config {
@@ -56,12 +68,53 @@ impl Default for Config {
             relay_url,
             compact_interval: env_parse("FASTR_COMPACT_INTERVAL", 21600),
             max_neg_records: env_parse("FASTR_MAX_NEG_RECORDS", 500_000),
+            max_event_tags: env_parse("FASTR_MAX_EVENT_TAGS", 2000),
+            max_content_length: env_parse("FASTR_MAX_CONTENT_LENGTH", 50 * 1024),
+            max_content_length_per_kind: parse_kind_limits("FASTR_MAX_CONTENT_LENGTH_PER_KIND"),
         }
+    }
+}
+
+impl Config {
+    /// Return the effective max content length for a given event kind.
+    pub fn content_limit_for_kind(&self, kind: u16) -> usize {
+        self.max_content_length_per_kind
+            .get(&kind)
+            .copied()
+            .unwrap_or(self.max_content_length)
     }
 }
 
 fn env_parse<T: std::str::FromStr>(key: &str, default: T) -> T {
     std::env::var(key).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+}
+
+/// Parse `kind:bytes,kind:bytes,...` from an env var into a HashMap.
+///
+/// Panics at startup if any token is malformed so configuration mistakes surface immediately.
+fn parse_kind_limits(key: &str) -> HashMap<u16, usize> {
+    let raw = match std::env::var(key) {
+        Ok(v) if !v.is_empty() => v,
+        _ => return HashMap::new(),
+    };
+    let mut map = HashMap::new();
+    for entry in raw.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let (k, v) = entry.split_once(':').unwrap_or_else(|| {
+            panic!("{key}: missing ':' separator in entry {entry:?}");
+        });
+        let kind = k.trim().parse::<u16>().unwrap_or_else(|e| {
+            panic!("{key}: bad kind in entry {entry:?}: {e}");
+        });
+        let limit = v.trim().parse::<usize>().unwrap_or_else(|e| {
+            panic!("{key}: bad byte limit in entry {entry:?}: {e}");
+        });
+        map.insert(kind, limit);
+    }
+    map
 }
 
 #[cfg(test)]
@@ -105,5 +158,57 @@ mod tests {
         let cfg = Config::default();
         assert_eq!(cfg.listen_addr.port(), 9000);
         unsafe { std::env::remove_var("FASTR_PORT") };
+    }
+
+    #[test]
+    fn test_parse_kind_limits_valid() {
+        unsafe { std::env::set_var("FASTR_TEST_KIND_LIMITS", "1053:102400,30023:204800") };
+        let map = parse_kind_limits("FASTR_TEST_KIND_LIMITS");
+        assert_eq!(map.get(&1053), Some(&102400));
+        assert_eq!(map.get(&30023), Some(&204800));
+        assert_eq!(map.len(), 2);
+        unsafe { std::env::remove_var("FASTR_TEST_KIND_LIMITS") };
+    }
+
+    #[test]
+    #[should_panic(expected = "bad byte limit")]
+    fn test_parse_kind_limits_bad_value_panics() {
+        unsafe { std::env::set_var("FASTR_TEST_KIND_LIMITS2", "1053:abc") };
+        parse_kind_limits("FASTR_TEST_KIND_LIMITS2");
+    }
+
+    #[test]
+    #[should_panic(expected = "missing ':'")]
+    fn test_parse_kind_limits_missing_separator_panics() {
+        unsafe { std::env::set_var("FASTR_TEST_KIND_LIMITS3", "bad") };
+        parse_kind_limits("FASTR_TEST_KIND_LIMITS3");
+    }
+
+    #[test]
+    #[should_panic(expected = "bad kind")]
+    fn test_parse_kind_limits_bad_kind_panics() {
+        unsafe { std::env::set_var("FASTR_TEST_KIND_LIMITS4", "notanumber:100") };
+        parse_kind_limits("FASTR_TEST_KIND_LIMITS4");
+    }
+
+    #[test]
+    fn test_content_limit_for_kind_override() {
+        let cfg = Config {
+            max_content_length: 50 * 1024,
+            max_content_length_per_kind: HashMap::from([(30023, 200 * 1024)]),
+            ..Config::default()
+        };
+        assert_eq!(cfg.content_limit_for_kind(30023), 200 * 1024);
+        assert_eq!(cfg.content_limit_for_kind(1), 50 * 1024);
+    }
+
+    #[test]
+    fn test_nip11_reports_kind1_limit() {
+        let cfg = Config {
+            max_content_length_per_kind: HashMap::from([(1, 69420)]),
+            ..Config::default()
+        };
+        // NIP-11 should report the kind-1 specific limit, not the global default
+        assert_eq!(cfg.content_limit_for_kind(1), 69420);
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -64,8 +64,8 @@ impl RelayInfo {
                 max_subscriptions: config.max_subscriptions_per_conn,
                 max_limit: config.max_limit,
                 max_subid_length: config.max_subid_length,
-                max_event_tags: 2000,
-                max_content_length: 8192,
+                max_event_tags: config.max_event_tags,
+                max_content_length: config.content_limit_for_kind(1),
                 created_at_upper_limit: CREATED_AT_WINDOW,
                 auth_required: false,
             },
@@ -299,5 +299,20 @@ mod tests {
     fn test_relay_info_response_content_type() {
         let resp = relay_info_response("{}");
         assert!(resp.contains("Content-Type: application/nostr+json"));
+    }
+
+    #[test]
+    fn test_relay_info_limits_reflect_config() {
+        let cfg = Config::default();
+        let info = RelayInfo::from_config(&cfg);
+        let json = relay_info_json(&info);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let lim = &v["limitation"];
+        assert_eq!(lim["max_message_length"], cfg.max_message_bytes);
+        assert_eq!(lim["max_subscriptions"], cfg.max_subscriptions_per_conn);
+        assert_eq!(lim["max_limit"], cfg.max_limit);
+        assert_eq!(lim["max_subid_length"], cfg.max_subid_length);
+        assert_eq!(lim["max_event_tags"], cfg.max_event_tags);
+        assert_eq!(lim["max_content_length"], cfg.content_limit_for_kind(1));
     }
 }

--- a/src/ws/handler.rs
+++ b/src/ws/handler.rs
@@ -243,7 +243,7 @@ where
                         let _ = out_tx.send(Out::Text(notice)).await;
                     }
                     Ok(ClientMsg::Event(ev)) => {
-                        handle_event(*ev, &store, &fanout, &out_tx, &auth).await;
+                        handle_event(*ev, &store, &fanout, &out_tx, &auth, &config).await;
                     }
                     Ok(ClientMsg::Req { sub_id, filters }) => {
                         if let Err(reason) = validate_sub_id(&sub_id, config.max_subid_length) {
@@ -349,8 +349,19 @@ async fn handle_event(
     fanout: &Arc<Fanout>,
     out_tx: &mpsc::Sender<Out>,
     auth: &AuthState,
+    config: &Config,
 ) {
     let id = ev.id.clone();
+
+    // Enforce advertised NIP-11 limits before expensive crypto validation.
+    if ev.tags.len() > config.max_event_tags {
+        send_ok(&id, false, "invalid: too many tags", out_tx).await;
+        return;
+    }
+    if ev.content.len() > config.content_limit_for_kind(ev.kind) {
+        send_ok(&id, false, "invalid: content too long", out_tx).await;
+        return;
+    }
 
     if let Err(reason) = validate_event(&ev) {
         send_ok(&id, false, &reason, out_tx).await;
@@ -813,6 +824,10 @@ mod tests {
     }
 
     async fn spawn_server() -> (u16, Arc<Store>) {
+        spawn_server_with_config(|_| {}).await
+    }
+
+    async fn spawn_server_with_config<F: FnOnce(&mut Config)>(configure: F) -> (u16, Arc<Store>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
 
@@ -820,10 +835,12 @@ mod tests {
         // Keep tempdir alive for the life of the server by moving it into the task.
         let store_path = dir.keep();
         let store = Arc::new(Store::open(&store_path).unwrap());
-        let config = Arc::new(Config {
+        let mut cfg = Config {
             relay_url: format!("ws://127.0.0.1:{port}"),
             ..Config::default()
-        });
+        };
+        configure(&mut cfg);
+        let config = Arc::new(cfg);
         let fanout = Fanout::new();
 
         let srv_store = Arc::clone(&store);
@@ -871,6 +888,104 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
         assert_eq!(v[0], "OK");
         assert_eq!(v[2], false, "bad sig must be rejected: {resp}");
+    }
+
+    #[tokio::test]
+    async fn test_event_with_too_many_tags_rejected() {
+        let (port, _) = spawn_server_with_config(|c| c.max_event_tags = 2).await;
+        let mut ws = connect(port).await;
+        let tags = vec![
+            Tag {
+                fields: vec!["t".into(), "a".into()],
+            },
+            Tag {
+                fields: vec!["t".into(), "b".into()],
+            },
+            Tag {
+                fields: vec!["t".into(), "c".into()],
+            },
+        ];
+        let ev = make_event(1, 1, 1_700_000_000, tags);
+        ws.send(TMsg::Text(event_msg(&ev).into())).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v[0], "OK");
+        assert_eq!(v[2], false, "event with too many tags must be rejected: {resp}");
+        assert!(
+            v[3].as_str().unwrap().contains("too many tags"),
+            "unexpected reason: {resp}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_event_with_oversized_content_rejected() {
+        // make_event's content is "k=<kind> t=<created_at>" which is > 3 bytes.
+        let (port, _) = spawn_server_with_config(|c| c.max_content_length = 3).await;
+        let mut ws = connect(port).await;
+        let ev = make_event(1, 1, 1_700_000_000, vec![]);
+        ws.send(TMsg::Text(event_msg(&ev).into())).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v[0], "OK");
+        assert_eq!(v[2], false, "oversized content must be rejected: {resp}");
+        assert!(
+            v[3].as_str().unwrap().contains("content too long"),
+            "unexpected reason: {resp}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_per_kind_content_limit_allows_larger_override() {
+        // Global default is 3 bytes, but kind 1 gets 1000 bytes via per-kind override.
+        let (port, _) = spawn_server_with_config(|c| {
+            c.max_content_length = 3;
+            c.max_content_length_per_kind.insert(1, 1000);
+        })
+        .await;
+        let mut ws = connect(port).await;
+        let ev = make_event(1, 1, 1_700_000_000, vec![]);
+        ws.send(TMsg::Text(event_msg(&ev).into())).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v[0], "OK");
+        assert_eq!(v[2], true, "kind-1 override must allow larger content: {resp}");
+    }
+
+    #[tokio::test]
+    async fn test_event_at_max_tag_limit_accepted() {
+        let limit = 3;
+        let (port, _) = spawn_server_with_config(move |c| c.max_event_tags = limit).await;
+        let mut ws = connect(port).await;
+        let tags = vec![
+            Tag {
+                fields: vec!["t".into(), "a".into()],
+            },
+            Tag {
+                fields: vec!["t".into(), "b".into()],
+            },
+            Tag {
+                fields: vec!["t".into(), "c".into()],
+            },
+        ];
+        let ev = make_event(1, 1, 1_700_000_000, tags);
+        ws.send(TMsg::Text(event_msg(&ev).into())).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v[0], "OK");
+        assert_eq!(v[2], true, "event at tag limit must be accepted: {resp}");
+    }
+
+    #[tokio::test]
+    async fn test_event_at_max_content_limit_accepted() {
+        let ev = make_event(1, 1, 1_700_000_000, vec![]);
+        let limit = ev.content.len();
+        let (port, _) = spawn_server_with_config(move |c| c.max_content_length = limit).await;
+        let mut ws = connect(port).await;
+        ws.send(TMsg::Text(event_msg(&ev).into())).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(v[0], "OK");
+        assert_eq!(v[2], true, "event at content limit must be accepted: {resp}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Add configurable `max_event_tags` (`FASTR_MAX_EVENT_TAGS`, default 2000) and `max_content_length` (`FASTR_MAX_CONTENT_LENGTH`, default 50 KiB) to `Config`
- Enforce these limits in `handle_event` before expensive crypto validation, rejecting oversized events with proper `["OK", id, false, "invalid: ..."]` messages
- Wire NIP-11 limitation fields to config values instead of hardcoded constants

Fixes #22, fixes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- The relay learned to keep promises: it now enforces advertised NIP‑11 limits up front. Events that exceed tag or content quotas are politely turned away with ["OK", id, false, "invalid: …"] before any expensive crypto or validation — cheaper, kinder, and less memory-hungry.
- Config got a few new knobs (and a map of mysterious powers): max_event_tags (FASTR_MAX_EVENT_TAGS, default 2000), max_content_length (FASTR_MAX_CONTENT_LENGTH, default 50 KiB), and max_content_length_per_kind parsed from FASTR_MAX_CONTENT_LENGTH_PER_KIND (comma-separated kind:bytes). Use content_limit_for_kind(kind) to discover the effective cap for any event kind.
- NIP‑11 now tells the truth: the relay-info document reports max_event_tags and max_content_length (reported as kind 1’s limit) from Config instead of hardcoded constants — what we advertise is now what we enforce.
- Protocol-level bouncer upgraded: tungstenite is configured via accept_async_with_config to set max_message_size and max_frame_size to config.max_message_bytes so oversized frames/messages are rejected at the WebSocket layer (the application still keeps an app-level check as a secondary guard).
- Early gatekeeping in the WS handler: handle_event now takes &Config and performs fast pre-validation checks. Too many tags or too-large content (using per-kind overrides) trigger early rejection with clear reasons, preventing downstream work and resource abuse.
- Per-kind limits are strict about correctness: FASTR_MAX_CONTENT_LENGTH_PER_KIND is parsed at startup into a HashMap; malformed entries cause startup failure (panic) so misconfigurations are surfaced immediately.
- Tests and integration armor: unit tests for parsing/override behavior and WebSocket integration tests for early rejection, per-kind limits, and NIP‑11 reporting were added/updated to lock this behavior in place.

Battle casualties (files changed, lines added/removed):

| File | Lines added | Lines removed | Notes |
|------|-----------:|--------------:|-------|
| src/config.rs | +105 | -0 | New config fields, parse_kind_limits (startup-validate), content_limit_for_kind(), and tests — config gains per-kind powers. |
| src/http.rs | +17 | -2 | Relay-info (NIP‑11) now mirrors Config (reports kind‑1 content limit and max_event_tags). |
| src/ws/handler.rs | +118 | -3 | WebSocket tungstenite limits wired in, handle_event now receives Config and rejects oversized/taggy events early; tests updated/added. |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->