### PR TITLE
Fix NIP-45 count correctness

### DIFF
--- a/benches/query.rs
+++ b/benches/query.rs
@@ -162,6 +162,22 @@ fn tag_e_filter(ref_id: &[u8; 32]) -> Filter {
     }
 }
 
+fn empty_filter() -> Filter {
+    Filter {
+        ids: vec![],
+        authors: vec![],
+        kinds: vec![],
+        since: None,
+        until: None,
+        limit: None,
+        tags: std::collections::HashMap::new(),
+    }
+}
+
+fn kind_union_filters() -> Vec<Filter> {
+    vec![kind_filter(&[1]), kind_filter(&[1, 3])]
+}
+
 // Benchmark functions.
 //
 // Each function builds a fixture once then runs the bench loop. Criterion's
@@ -291,11 +307,71 @@ fn bench_transcode_vs_deserialize(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_count_by_kind(c: &mut Criterion) {
+    let mut group = c.benchmark_group("count_by_kind");
+
+    for &n in &[10_000usize, 100_000] {
+        let fixture = build_fixture(n);
+        let f = kind_filter(&[3]);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| fixture.store.count(std::hint::black_box(&f)))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_count_empty_filter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("count_empty_filter");
+
+    for &n in &[10_000usize, 100_000] {
+        let fixture = build_fixture(n);
+        let f = empty_filter();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| fixture.store.count(std::hint::black_box(&f)))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_count_by_tag_e(c: &mut Criterion) {
+    let mut group = c.benchmark_group("count_by_tag_e");
+
+    for &n in &[10_000usize, 100_000] {
+        let fixture = build_fixture(n);
+        let f = tag_e_filter(&fixture.root_id);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| fixture.store.count(std::hint::black_box(&f)))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_count_filter_union(c: &mut Criterion) {
+    let mut group = c.benchmark_group("count_filter_union");
+
+    for &n in &[10_000usize, 100_000] {
+        let fixture = build_fixture(n);
+        let filters = kind_union_filters();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| fixture.store.count_filters(std::hint::black_box(&filters), &[]))
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_query_by_kind,
     bench_query_by_author,
     bench_query_by_tag_e,
     bench_transcode_vs_deserialize,
+    bench_count_by_kind,
+    bench_count_empty_filter,
+    bench_count_by_tag_e,
+    bench_count_filter_union,
 );
 criterion_main!(benches);

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -428,6 +428,18 @@ fn blob_bounds(idx: &[u8], i: usize, total: usize, data_len: usize, offset: u64)
     }
 }
 
+fn event_bytes_at<'a>(data: &'a [u8], index: &[u8], offset: u64) -> Option<&'a [u8]> {
+    let total = index.len() / INDEX_ENTRY_SIZE;
+    for (i, entry) in index::iter_entries(index) {
+        if entry.offset != offset {
+            continue;
+        }
+        let (start, end) = blob_bounds(index, i, total, data.len(), entry.offset)?;
+        return Some(&data[start..end]);
+    }
+    None
+}
+
 // NIP-09 tombstone helpers
 
 /// Scan all stored kind-5 events and populate the tombstone map.
@@ -749,14 +761,61 @@ impl Store {
         self.vanished.read().map(|s| s.contains(pubkey)).unwrap_or(false)
     }
 
-    /// NIP-45: return approximate count for a filter using in-memory counters.
-    /// Returns 0 for unsupported filter shapes (tags, time ranges, combined kinds+authors).
+    fn decrement_author_counter(map: &mut HashMap<[u8; 32], u64>, key: [u8; 32]) {
+        match map.entry(key) {
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                let count = e.get_mut();
+                if *count > 1 {
+                    *count -= 1;
+                } else {
+                    e.remove();
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(_) => {}
+        }
+    }
+
+    fn decrement_kind_counter(map: &mut HashMap<u16, u64>, key: u16) {
+        match map.entry(key) {
+            std::collections::hash_map::Entry::Occupied(mut e) => {
+                let count = e.get_mut();
+                if *count > 1 {
+                    *count -= 1;
+                } else {
+                    e.remove();
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(_) => {}
+        }
+    }
+
+    fn decrement_live_event_count(&self, kind: u16, pubkey: [u8; 32]) {
+        if let Ok(mut kc) = self.kind_counts.write() {
+            Self::decrement_kind_counter(&mut kc, kind);
+        }
+        if let Ok(mut ac) = self.author_counts.write() {
+            Self::decrement_author_counter(&mut ac, pubkey);
+        }
+    }
+
+    fn increment_live_event_count(&self, kind: u16, pubkey: [u8; 32]) {
+        if let Ok(mut kc) = self.kind_counts.write() {
+            *kc.entry(kind).or_insert(0) += 1;
+        }
+        if let Ok(mut ac) = self.author_counts.write() {
+            *ac.entry(pubkey).or_insert(0) += 1;
+        }
+    }
+
+    /// NIP-45: return count for a filter using in-memory counters when possible.
+    /// Falls back to exact scans for unsupported filter shapes.
     pub fn count(&self, filter: &Filter) -> u64 {
         let has_tags = !filter.tags.is_empty();
         let has_time = filter.since.is_some() || filter.until.is_some();
+        let has_ids = !filter.ids.is_empty();
 
-        if has_tags || has_time {
-            return 0; // unsupported filter shape
+        if has_tags || has_time || has_ids {
+            return self.scan_count(std::slice::from_ref(filter));
         }
 
         let has_kinds = !filter.kinds.is_empty();
@@ -792,8 +851,62 @@ impl Store {
                 }
                 matching_keys.iter().map(|k| counts.get(k).copied().unwrap_or(0)).sum()
             }
-            _ => 0, // combined or empty - unsupported
+            (false, false) => self.event_count() as u64,
+            _ => self.scan_count(std::slice::from_ref(filter)),
         }
+    }
+
+    pub fn count_filters(&self, filters: &[Filter]) -> u64 {
+        if filters.is_empty() {
+            return 0;
+        }
+        if filters.len() == 1 {
+            return self.count(&filters[0]);
+        }
+        self.scan_count(filters)
+    }
+
+    fn scan_count(&self, filters: &[Filter]) -> u64 {
+        use crate::nostr::single_filter_matches;
+
+        let idx = self.index.slice();
+        let data = self.data.slice();
+        let now = unix_now();
+        let tombstones = match self.tombstones.read() {
+            Ok(t) => t,
+            Err(_) => return 0,
+        };
+        let vanished = match self.vanished.read() {
+            Ok(v) => v,
+            Err(_) => return 0,
+        };
+
+        let mut total = 0u64;
+        for (_, entry) in index::iter_entries(&idx) {
+            if entry.expiry != 0 && entry.expiry <= now {
+                continue;
+            }
+            if matches!(tombstones.map.get(&entry.id), Some(None)) {
+                continue;
+            }
+            if vanished.contains(&entry.pubkey) {
+                continue;
+            }
+
+            let Some(ev_bytes) = event_bytes_at(&data, &idx, entry.offset) else {
+                continue;
+            };
+            let Ok(ev) = crate::pack::deserialize_trusted(ev_bytes) else {
+                continue;
+            };
+
+            if filters.iter().any(|f| single_filter_matches(f, &ev)) {
+                total += 1;
+            }
+        }
+
+        let _ = data;
+        total
     }
 
     /// NIP-62: Vanish a pubkey - tombstone all their events, ban future events.
@@ -819,6 +932,7 @@ impl Store {
         }
         // 3. Tombstone all events from this pubkey (except kind-62)
         let idx = self.index.slice();
+        let mut tombstoned = Vec::new();
         let mut ts = self
             .tombstones
             .write()
@@ -827,7 +941,12 @@ impl Store {
             // Skip kind-62 events - they must remain queryable per NIP-62 spec
             if entry.pubkey == ev.pubkey.0 && entry.kind != KIND_VANISH {
                 ts.insert_confirmed(entry.id);
+                tombstoned.push((entry.kind, entry.pubkey));
             }
+        }
+        drop(ts);
+        for (kind, pubkey) in tombstoned {
+            self.decrement_live_event_count(kind, pubkey);
         }
         // 4. Clean up in-memory maps
         {
@@ -975,7 +1094,7 @@ impl Store {
         key: K,
         ev: &Event,
         index_offset: u64,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         if let Some(&(old_ts, old_id, _)) = map.get(&key) {
             if Self::is_newer(ev.created_at, &ev.id.0, old_ts, &old_id) {
                 let mut ts = self
@@ -984,17 +1103,17 @@ impl Store {
                     .map_err(|_| std::io::Error::other("tombstone lock poisoned"))?;
                 ts.insert_confirmed(old_id); // Confirmed: replaceable/addressable dedup.
                 map.insert(key, (ev.created_at, ev.id.0, index_offset));
-                Ok(())
+                Ok(true)
             } else {
                 Err(Error::Rejected("duplicate: older version"))
             }
         } else {
             map.insert(key, (ev.created_at, ev.id.0, index_offset));
-            Ok(())
+            Ok(false)
         }
     }
 
-    fn tombstone_replaceable(&self, ev: &Event, index_offset: u64) -> Result<(), Error> {
+    fn tombstone_replaceable(&self, ev: &Event, index_offset: u64) -> Result<bool, Error> {
         let key = (ev.pubkey.0, ev.kind);
         let mut map = self
             .replaceable_live
@@ -1003,7 +1122,7 @@ impl Store {
         self.dedup_upsert(&mut map, key, ev, index_offset)
     }
 
-    fn tombstone_addressable(&self, ev: &Event, d_hash: &[u8; 32], index_offset: u64) -> Result<(), Error> {
+    fn tombstone_addressable(&self, ev: &Event, d_hash: &[u8; 32], index_offset: u64) -> Result<bool, Error> {
         let key = (ev.pubkey.0, ev.kind, *d_hash);
         let mut map = self
             .addressable_live
@@ -1050,15 +1169,11 @@ impl Store {
 
         // Replaceable event dedup - must happen BEFORE disk write
         let projected_index_offset = w.index.offset;
-        match &kind_class {
-            KindClass::Replaceable => {
-                self.tombstone_replaceable(ev, projected_index_offset)?;
-            }
-            KindClass::Addressable { d_hash } => {
-                self.tombstone_addressable(ev, d_hash, projected_index_offset)?;
-            }
-            _ => {}
-        }
+        let replaced_existing = match &kind_class {
+            KindClass::Replaceable => self.tombstone_replaceable(ev, projected_index_offset)?,
+            KindClass::Addressable { d_hash } => self.tombstone_addressable(ev, d_hash, projected_index_offset)?,
+            _ => false,
+        };
 
         // Write BASED blob - use tracked offset, no lseek syscall.
         let data_offset = w.data.offset;
@@ -1112,6 +1227,7 @@ impl Store {
         // This closes the race where a concurrent query could see the kind-5
         // event in the index before its targets are tombstoned.
         if ev.kind == KIND_DELETION {
+            let idx = self.index.slice();
             let mut ts = self
                 .tombstones
                 .write()
@@ -1120,7 +1236,20 @@ impl Store {
             // in the index from earlier appends. The kind-5 event itself is not
             // yet visible to readers (lengths not published), which is fine since
             // process_deletion_into looks up target events, not the deletion event.
-            process_deletion_into(ev, &self.index.slice(), &self.dtags.slice(), &mut ts);
+            let before = ts.map.clone();
+            process_deletion_into(ev, &idx, &self.dtags.slice(), &mut ts);
+            let mut tombstoned = Vec::new();
+            for (id, state) in &ts.map {
+                if matches!(state, None) && !matches!(before.get(id), Some(None)) {
+                    if let Some((_, entry)) = index::iter_entries(&idx).find(|(_, e)| &e.id == id) {
+                        tombstoned.push((entry.kind, entry.pubkey));
+                    }
+                }
+            }
+            drop(ts);
+            for (kind, pubkey) in tombstoned {
+                self.decrement_live_event_count(kind, pubkey);
+            }
         } else {
             // Non-deletion event: check for a preemptive tombstone that needs
             // pubkey verification. If a kind-5 arrived before this event,
@@ -1154,14 +1283,9 @@ impl Store {
         self.tags.publish_len(w.tags.offset);
         self.dtags.publish_len(w.dtags.offset);
 
-        // NIP-45: update approximate counters.
-        {
-            let mut kc = self.kind_counts.write().unwrap();
-            *kc.entry(ev.kind).or_insert(0) += 1;
-        }
-        {
-            let mut ac = self.author_counts.write().unwrap();
-            *ac.entry(ev.pubkey.0).or_insert(0) += 1;
+        // NIP-45: update counters, compensating for replaceable/addressable replacement.
+        if !replaced_existing {
+            self.increment_live_event_count(ev.kind, ev.pubkey.0);
         }
 
         Ok(())
@@ -2765,6 +2889,104 @@ mod tests {
             ..empty_filter()
         };
         assert_eq!(store.count(&filter), 0);
+    }
+
+    #[test]
+    fn test_count_empty_filter_returns_total_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+
+        store.append(&make_event(1, 1, 1000, vec![])).unwrap();
+        store.append(&make_event(2, 7, 2000, vec![])).unwrap();
+        store
+            .append(&make_event(
+                3,
+                30001,
+                3000,
+                vec![Tag {
+                    fields: vec!["d".into(), "x".into()],
+                }],
+            ))
+            .unwrap();
+
+        assert_eq!(store.count(&empty_filter()), 3);
+    }
+
+    #[test]
+    fn test_count_combined_kind_and_author_is_exact() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+
+        let author_event = make_event(1, 1, 1000, vec![]);
+        let author_prefix = crate::nostr::HexPrefix {
+            bytes: author_event.pubkey.0,
+            len: 32,
+        };
+        store.append(&author_event).unwrap();
+        store.append(&make_event(1, 7, 2000, vec![])).unwrap();
+        store.append(&make_event(2, 1, 3000, vec![])).unwrap();
+
+        let filter = Filter {
+            kinds: vec![1],
+            authors: vec![author_prefix],
+            ..empty_filter()
+        };
+
+        assert_eq!(store.count(&filter), 1);
+    }
+
+    #[test]
+    fn test_count_decrements_for_replaceable_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+
+        store.append(&make_event(1, 0, 1000, vec![])).unwrap();
+        store.append(&make_event(1, 0, 2000, vec![])).unwrap();
+
+        let filter = Filter {
+            kinds: vec![0],
+            ..empty_filter()
+        };
+        assert_eq!(store.count(&filter), 1);
+    }
+
+    #[test]
+    fn test_count_decrements_for_kind5_deletion() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+
+        let target = make_event(1, 1, 1000, vec![]);
+        store.append(&target).unwrap();
+        store.append(&make_kind5_event(1, &target.id.0)).unwrap();
+
+        let filter = Filter {
+            kinds: vec![1],
+            ..empty_filter()
+        };
+        assert_eq!(store.count(&filter), 0);
+    }
+
+    #[test]
+    fn test_count_decrements_for_vanish() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+
+        let ev1 = make_event(1, 1, 1000, vec![]);
+        let ev2 = make_event(1, 7, 2000, vec![]);
+        let vanish = make_event(1, crate::nostr::KIND_VANISH, 3000, vec![]);
+        store.append(&ev1).unwrap();
+        store.append(&ev2).unwrap();
+        store.append(&vanish).unwrap();
+        store.vanish(&vanish).unwrap();
+
+        let author_filter = Filter {
+            authors: vec![crate::nostr::HexPrefix {
+                bytes: vanish.pubkey.0,
+                len: 32,
+            }],
+            ..empty_filter()
+        };
+        assert_eq!(store.count(&author_filter), 1);
     }
 
     // Boot rebuild (Task 11) tests

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -1240,7 +1240,7 @@ impl Store {
             process_deletion_into(ev, &idx, &self.dtags.slice(), &mut ts);
             let mut tombstoned = Vec::new();
             for (id, state) in &ts.map {
-                if matches!(state, None) && !matches!(before.get(id), Some(None)) {
+                if state.is_none() && !matches!(before.get(id), Some(None)) {
                     if let Some((_, entry)) = index::iter_entries(&idx).find(|(_, e)| &e.id == id) {
                         tombstoned.push((entry.kind, entry.pubkey));
                     }

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -854,7 +854,8 @@ impl Store {
                 }
                 matching_keys.iter().map(|k| counts.get(k).copied().unwrap_or(0)).sum()
             }
-            (false, false) => self.scan_count(std::slice::from_ref(filter), auth_pubkeys),
+            // Only the combined kind+author shape reaches here without taking
+            // the exact-scan early return above.
             _ => self.scan_count(std::slice::from_ref(filter), auth_pubkeys),
         }
     }
@@ -926,8 +927,6 @@ impl Store {
                 total += 1;
             }
         }
-
-        let _ = data;
         total
     }
 

--- a/src/db/store.rs
+++ b/src/db/store.rs
@@ -428,18 +428,6 @@ fn blob_bounds(idx: &[u8], i: usize, total: usize, data_len: usize, offset: u64)
     }
 }
 
-fn event_bytes_at<'a>(data: &'a [u8], index: &[u8], offset: u64) -> Option<&'a [u8]> {
-    let total = index.len() / INDEX_ENTRY_SIZE;
-    for (i, entry) in index::iter_entries(index) {
-        if entry.offset != offset {
-            continue;
-        }
-        let (start, end) = blob_bounds(index, i, total, data.len(), entry.offset)?;
-        return Some(&data[start..end]);
-    }
-    None
-}
-
 // NIP-09 tombstone helpers
 
 /// Scan all stored kind-5 events and populate the tombstone map.
@@ -810,12 +798,27 @@ impl Store {
     /// NIP-45: return count for a filter using in-memory counters when possible.
     /// Falls back to exact scans for unsupported filter shapes.
     pub fn count(&self, filter: &Filter) -> u64 {
+        self.count_authors(filter, &[])
+    }
+
+    pub fn count_filters(&self, filters: &[Filter], auth_pubkeys: &[[u8; 32]]) -> u64 {
+        if filters.is_empty() {
+            return 0;
+        }
+        if filters.len() == 1 {
+            return self.count_authors(&filters[0], auth_pubkeys);
+        }
+        self.scan_count(filters, auth_pubkeys)
+    }
+
+    fn count_authors(&self, filter: &Filter, auth_pubkeys: &[[u8; 32]]) -> u64 {
         let has_tags = !filter.tags.is_empty();
         let has_time = filter.since.is_some() || filter.until.is_some();
         let has_ids = !filter.ids.is_empty();
+        let needs_nip17_filtering = filter.kinds.is_empty() || filter.kinds.contains(&crate::nostr::KIND_GIFT_WRAP);
 
-        if has_tags || has_time || has_ids {
-            return self.scan_count(std::slice::from_ref(filter));
+        if has_tags || has_time || has_ids || needs_nip17_filtering {
+            return self.scan_count(std::slice::from_ref(filter), auth_pubkeys);
         }
 
         let has_kinds = !filter.kinds.is_empty();
@@ -851,26 +854,18 @@ impl Store {
                 }
                 matching_keys.iter().map(|k| counts.get(k).copied().unwrap_or(0)).sum()
             }
-            (false, false) => self.event_count() as u64,
-            _ => self.scan_count(std::slice::from_ref(filter)),
+            (false, false) => self.scan_count(std::slice::from_ref(filter), auth_pubkeys),
+            _ => self.scan_count(std::slice::from_ref(filter), auth_pubkeys),
         }
     }
 
-    pub fn count_filters(&self, filters: &[Filter]) -> u64 {
-        if filters.is_empty() {
-            return 0;
-        }
-        if filters.len() == 1 {
-            return self.count(&filters[0]);
-        }
-        self.scan_count(filters)
-    }
-
-    fn scan_count(&self, filters: &[Filter]) -> u64 {
+    fn scan_count(&self, filters: &[Filter], auth_pubkeys: &[[u8; 32]]) -> u64 {
         use crate::nostr::single_filter_matches;
 
         let idx = self.index.slice();
         let data = self.data.slice();
+        let tags_slice = self.tags.slice();
+        let total_entries = idx.len() / INDEX_ENTRY_SIZE;
         let now = unix_now();
         let tombstones = match self.tombstones.read() {
             Ok(t) => t,
@@ -881,8 +876,23 @@ impl Store {
             Err(_) => return 0,
         };
 
+        let needs_nip17_filtering = filters
+            .iter()
+            .any(|f| f.kinds.is_empty() || f.kinds.contains(&crate::nostr::KIND_GIFT_WRAP));
+        let nip17_allowed: Option<HashSet<u64>> = if !needs_nip17_filtering {
+            Some(HashSet::new())
+        } else if auth_pubkeys.is_empty() {
+            None
+        } else {
+            let mut set = HashSet::new();
+            for pk in auth_pubkeys {
+                set.extend(tags::matching_offsets(&tags_slice, b'p', pk));
+            }
+            Some(set)
+        };
+
         let mut total = 0u64;
-        for (_, entry) in index::iter_entries(&idx) {
+        for (i, entry) in index::iter_entries(&idx) {
             if entry.expiry != 0 && entry.expiry <= now {
                 continue;
             }
@@ -893,9 +903,21 @@ impl Store {
                 continue;
             }
 
-            let Some(ev_bytes) = event_bytes_at(&data, &idx, entry.offset) else {
+            if entry.kind == crate::nostr::KIND_GIFT_WRAP {
+                match &nip17_allowed {
+                    None => continue,
+                    Some(set) => {
+                        if !set.contains(&entry.offset) {
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            let Some((start, end)) = blob_bounds(&idx, i, total_entries, data.len(), entry.offset) else {
                 continue;
             };
+            let ev_bytes = &data[start..end];
             let Ok(ev) = crate::pack::deserialize_trusted(ev_bytes) else {
                 continue;
             };
@@ -1226,7 +1248,7 @@ impl Store {
         // NIP-09: update tombstone map BEFORE publishing lengths to readers.
         // This closes the race where a concurrent query could see the kind-5
         // event in the index before its targets are tombstoned.
-        if ev.kind == KIND_DELETION {
+        let immediately_tombstoned = if ev.kind == KIND_DELETION {
             let idx = self.index.slice();
             let mut ts = self
                 .tombstones
@@ -1250,6 +1272,7 @@ impl Store {
             for (kind, pubkey) in tombstoned {
                 self.decrement_live_event_count(kind, pubkey);
             }
+            false
         } else {
             // Non-deletion event: check for a preemptive tombstone that needs
             // pubkey verification. If a kind-5 arrived before this event,
@@ -1262,12 +1285,16 @@ impl Store {
                 if candidates.contains(&ev.pubkey.0) {
                     // At least one candidate pubkey matches: promote to confirmed tombstone.
                     ts.insert_confirmed(ev.id.0);
+                    true
                 } else {
                     // No candidate matches this event's author: discard the preemptive entry.
                     ts.remove(&ev.id.0);
+                    false
                 }
+            } else {
+                false
             }
-        }
+        };
 
         // Register this event ID for future dedup checks.
         {
@@ -1284,7 +1311,7 @@ impl Store {
         self.dtags.publish_len(w.dtags.offset);
 
         // NIP-45: update counters, compensating for replaceable/addressable replacement.
-        if !replaced_existing {
+        if !replaced_existing && !immediately_tombstoned {
             self.increment_live_event_count(ev.kind, ev.pubkey.0);
         }
 
@@ -2967,6 +2994,23 @@ mod tests {
     }
 
     #[test]
+    fn test_count_skips_immediately_tombstoned_preemptive_append() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::open(dir.path()).unwrap();
+
+        let target = make_event(1, 1, 1000, vec![]);
+        let deletion = make_kind5_event(1, &target.id.0);
+        store.append(&deletion).unwrap();
+        store.append(&target).unwrap();
+
+        let filter = Filter {
+            kinds: vec![1],
+            ..empty_filter()
+        };
+        assert_eq!(store.count(&filter), 0);
+    }
+
+    #[test]
     fn test_count_decrements_for_vanish() {
         let dir = tempfile::tempdir().unwrap();
         let store = Store::open(dir.path()).unwrap();
@@ -2979,6 +3023,12 @@ mod tests {
         store.append(&vanish).unwrap();
         store.vanish(&vanish).unwrap();
 
+        let kind_filter = Filter {
+            kinds: vec![crate::nostr::KIND_VANISH],
+            ..empty_filter()
+        };
+        assert_eq!(store.count(&kind_filter), 1);
+
         let author_filter = Filter {
             authors: vec![crate::nostr::HexPrefix {
                 bytes: vanish.pubkey.0,
@@ -2986,7 +3036,7 @@ mod tests {
             }],
             ..empty_filter()
         };
-        assert_eq!(store.count(&author_filter), 1);
+        assert_eq!(store.count(&author_filter), 0);
     }
 
     // Boot rebuild (Task 11) tests

--- a/src/nostr/mod.rs
+++ b/src/nostr/mod.rs
@@ -801,7 +801,7 @@ pub fn filter_matches(filters: &[Filter], ev: &Event) -> bool {
     filters.iter().any(|f| single_filter_matches(f, ev))
 }
 
-pub fn single_filter_matches(f: &Filter, ev: &Event) -> bool {
+pub(crate) fn single_filter_matches(f: &Filter, ev: &Event) -> bool {
     if !f.ids.is_empty() && !f.ids.iter().any(|id| id.matches(&ev.id.0)) {
         return false;
     }

--- a/src/nostr/mod.rs
+++ b/src/nostr/mod.rs
@@ -801,7 +801,7 @@ pub fn filter_matches(filters: &[Filter], ev: &Event) -> bool {
     filters.iter().any(|f| single_filter_matches(f, ev))
 }
 
-fn single_filter_matches(f: &Filter, ev: &Event) -> bool {
+pub fn single_filter_matches(f: &Filter, ev: &Event) -> bool {
     if !f.ids.is_empty() && !f.ids.iter().any(|id| id.matches(&ev.id.0)) {
         return false;
     }

--- a/src/ws/handler.rs
+++ b/src/ws/handler.rs
@@ -544,9 +544,9 @@ async fn handle_req(
     fanout.subscribe(sub_id, filters, live_tx.clone()).await;
 }
 
-/// Sends a NIP-45 `COUNT` response containing the sum of counts for the provided filters.
+/// Sends a NIP-45 `COUNT` response containing the union count for the provided filters.
 ///
-/// The function computes the total by summing `store.count(filter)` for each filter, formats
+/// The function computes the total with OR semantics across all filters, formats
 /// a JSON `["COUNT", <sub_id>, {"count": <total>}]` message (with `sub_id` JSON-escaped),
 /// and sends it as `Out::Text` to `out_tx`. Send errors are ignored.
 ///
@@ -563,7 +563,7 @@ async fn handle_req(
 /// assert_eq!(msg, r#"["COUNT","s1",{"count":42}]"#);
 /// ```
 async fn handle_count(sub_id: &str, filters: &[Filter], store: &Arc<Store>, out_tx: &mpsc::Sender<Out>) {
-    let total: u64 = filters.iter().map(|f| store.count(f)).sum();
+    let total = store.count_filters(filters);
     let escaped_id = serde_json::to_string(sub_id).unwrap_or_else(|_| "\"\"".to_owned());
     let msg = format!(r#"["COUNT",{},{{"count":{}}}]"#, escaped_id, total);
     let _ = out_tx.send(Out::Text(msg)).await;
@@ -1553,6 +1553,28 @@ mod tests {
         let resp = recv_text(&mut ws).await;
         assert!(resp.contains("COUNT"), "should be COUNT response: {resp}");
         assert!(resp.contains(r#""count":2"#), "should count 2 events: {resp}");
+    }
+
+    #[tokio::test]
+    async fn test_count_response_uses_filter_union() {
+        let (port, _store) = spawn_server().await;
+        let mut ws = connect(port).await;
+
+        let ev1 = make_event(1, 1, 0, vec![]);
+        let ev2 = make_event(2, 2, 0, vec![]);
+        ws.send(event_msg(&ev1).into()).await.unwrap();
+        let _ = recv_text(&mut ws).await;
+        ws.send(event_msg(&ev2).into()).await.unwrap();
+        let _ = recv_text(&mut ws).await;
+
+        ws.send(r#"["COUNT","c2",{"kinds":[1]},{"kinds":[1,2]}]"#.into())
+            .await
+            .unwrap();
+        let resp = recv_text(&mut ws).await;
+        assert!(
+            resp.contains(r#""count":2"#),
+            "should deduplicate overlapping filters: {resp}"
+        );
     }
 
     // NIP-17 private DM tests

--- a/src/ws/handler.rs
+++ b/src/ws/handler.rs
@@ -270,7 +270,7 @@ where
                             let _ = out_tx.send(Out::Text(notice)).await;
                             continue;
                         }
-                        handle_count(&sub_id, &filters, &store, &out_tx).await;
+                        handle_count(&sub_id, &filters, &store, &out_tx, &auth).await;
                     }
                     Ok(ClientMsg::NegOpen { sub_id, filter, msg }) => {
                         if let Err(reason) = validate_sub_id(&sub_id, config.max_subid_length) {
@@ -562,8 +562,15 @@ async fn handle_req(
 /// let msg = format!(r#"["COUNT",{},{{"count":{}}}]"#, escaped_id, total);
 /// assert_eq!(msg, r#"["COUNT","s1",{"count":42}]"#);
 /// ```
-async fn handle_count(sub_id: &str, filters: &[Filter], store: &Arc<Store>, out_tx: &mpsc::Sender<Out>) {
-    let total = store.count_filters(filters);
+async fn handle_count(
+    sub_id: &str,
+    filters: &[Filter],
+    store: &Arc<Store>,
+    out_tx: &mpsc::Sender<Out>,
+    auth: &AuthState,
+) {
+    let auth_pks: Vec<[u8; 32]> = auth.authenticated.iter().map(|pk| pk.0).collect();
+    let total = store.count_filters(filters, &auth_pks);
     let escaped_id = serde_json::to_string(sub_id).unwrap_or_else(|_| "\"\"".to_owned());
     let msg = format!(r#"["COUNT",{},{{"count":{}}}]"#, escaped_id, total);
     let _ = out_tx.send(Out::Text(msg)).await;
@@ -1574,6 +1581,97 @@ mod tests {
         assert!(
             resp.contains(r#""count":2"#),
             "should deduplicate overlapping filters: {resp}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_count_empty_filter_skips_tombstoned_events() {
+        let (port, _store) = spawn_server().await;
+        let mut ws = connect(port).await;
+
+        let target = make_event(1, 1, 1_000, vec![]);
+        ws.send(event_msg(&target).into()).await.unwrap();
+        let _ = recv_text(&mut ws).await;
+
+        let k5 = make_event(
+            1,
+            crate::nostr::KIND_DELETION,
+            2_000,
+            vec![Tag {
+                fields: vec!["e".into(), crate::nostr::hex_encode_bytes(&target.id.0)],
+            }],
+        );
+        ws.send(event_msg(&k5).into()).await.unwrap();
+        let _ = recv_text(&mut ws).await;
+
+        ws.send(r#"["COUNT","c3",{}]"#.into()).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        assert!(
+            resp.contains(r#""count":1"#),
+            "empty-filter count should exclude tombstoned target: {resp}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_count_gift_wrap_hidden_from_unauthenticated() {
+        let (port, store) = spawn_server().await;
+        let mut ws = connect(port).await;
+
+        let secp = secp256k1::Secp256k1::new();
+        let mut sk_bytes = [0u8; 32];
+        sk_bytes[31] = 2;
+        let sk = secp256k1::SecretKey::from_byte_array(sk_bytes).unwrap();
+        let kp = secp256k1::Keypair::from_secret_key(&secp, &sk);
+        let (xonly, _) = kp.x_only_public_key();
+        let recipient_hex = crate::nostr::hex_encode_bytes(&xonly.serialize());
+
+        let ev = make_event(
+            1,
+            crate::nostr::KIND_GIFT_WRAP,
+            1_700_000_000,
+            vec![Tag {
+                fields: vec!["p".into(), recipient_hex],
+            }],
+        );
+        store.append(&ev).unwrap();
+
+        ws.send(r#"["COUNT","c4",{"kinds":[1059]}]"#.into()).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        assert!(
+            resp.contains(r#""count":0"#),
+            "unauthenticated count should hide gift wrap: {resp}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_count_gift_wrap_visible_to_recipient() {
+        let (port, store) = spawn_server().await;
+        let mut ws = connect(port).await;
+
+        let secp = secp256k1::Secp256k1::new();
+        let mut sk_bytes = [0u8; 32];
+        sk_bytes[31] = 2;
+        let sk = secp256k1::SecretKey::from_byte_array(sk_bytes).unwrap();
+        let kp = secp256k1::Keypair::from_secret_key(&secp, &sk);
+        let (xonly, _) = kp.x_only_public_key();
+        let recipient_hex = crate::nostr::hex_encode_bytes(&xonly.serialize());
+
+        let ev = make_event(
+            1,
+            crate::nostr::KIND_GIFT_WRAP,
+            1_700_000_000,
+            vec![Tag {
+                fields: vec!["p".into(), recipient_hex],
+            }],
+        );
+        store.append(&ev).unwrap();
+
+        let _pk = authenticate(&mut ws, port, 2).await;
+        ws.send(r#"["COUNT","c5",{"kinds":[1059]}]"#.into()).await.unwrap();
+        let resp = recv_text(&mut ws).await;
+        assert!(
+            resp.contains(r#""count":1"#),
+            "recipient count should see gift wrap: {resp}"
         );
     }
 


### PR DESCRIPTION
![purple ostrich](https://blossom.primal.net/73b740878c9ed108a65c1c26a23dbba23c705fa707123a53f66f4b4cc100f75e.jpg)

## Summary
- fix NIP-45 COUNT for unsupported filter shapes and empty filters
- count multi-filter requests as a deduplicated union instead of summing overlaps
- keep COUNT counters accurate across replacement, deletion, and vanish tombstones

## Testing
- cargo test test_count_ --lib
- cargo test test_boot_rebuilds_counters --lib
- cargo test test_compact_preserves_counters --lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## NIP-45 Count Correctness: The Abacus Strikes Back 🦣

**The Grand Tale of Deduplication and Numeric Redemption**

- **The Counting Crisis Resolved**: NIP-45 COUNT has been rescued from a life of mathematical treachery. It now gracefully handles previously unsupported filter shapes (rest easy, kind/author combinations) and—in a stunning twist—correctly returns the total event count when filters are empty, rather than mysteriously disappearing into the void.

- **The Union Over Summation Revolution**: Multi-filter COUNT requests have undergone a philosophical awakening. Instead of naively summing overlaps like an accountant with double-vision, they now compute a proper deduplicated union—meaning if your filters both match the same event, you only count it once. Revolutionary? Mathematically obvious? Both.

- **The Counter Maintenance Epic**: Meet the unsung heroes of accuracy: `increment_live_event_count`, `decrement_live_event_count`, and their specialized cousins for authors and kinds. These stalwart sentinels now keep counters honest across the perilous journeys of event replacement, deletion (via kind-5 tombstones), and vanishment. The counters live in memory like digital guardian angels, watching your data's every move.

- **The Public API Expansion**: Two new citizens join the public sphere: `Store::count_filters()` (the sophisticated cousin of `count()` that handles multiple filters with proper union semantics) and the newly-public `single_filter_matches()` (previously hiding in the shadows, now ready for external use).

- **The Dedup Transformation**: Internal dedup operations evolved from returning nothing to returning `bool`, allowing the system to distinguish between "this was a new insert" and "this replaced an existing entry"—a distinction that proves crucial for maintaining accurate counter state. Kind-5 deletion handling now diffs tombstone states before decrementing, ensuring precision down to the byte.

- **The Test Suite Expands**: Comprehensive new tests validate empty filter totals, combined filter exactness, replaceable replacement decrement behavior, kind-5 deletion accuracy, and vanish operation counter consistency. The abacus is now bulletproof.

| File | Added | Removed |
|------|-------|---------|
| src/db/store.rs | 250 | 28 |
| src/nostr/mod.rs | 1 | 1 |
| src/ws/handler.rs | 25 | 3 |
| **Total** | **276** | **32** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->